### PR TITLE
add `camlp-streams` to `opam` file

### DIFF
--- a/opam
+++ b/opam
@@ -18,6 +18,7 @@ depends: [
   "base-bytes"
   "base-unix"
   "camlidl"
+  "camlp-streams"
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.5"}
 ]


### PR DESCRIPTION
In https://github.com/ygrek/ocaml-hdfs/commit/782d8f517cb2fe14b791a0eb3834d6d9d9d59d0a, `camlp-streams` was added as dep, but opam was unaware of it.